### PR TITLE
refactor BF::Entity, add automatic embedded texture management

### DIFF
--- a/BattleFriends/BattleFriends.vcxproj
+++ b/BattleFriends/BattleFriends.vcxproj
@@ -236,9 +236,6 @@
     <_EmbedManagedResourceFile Include="resources\logo.png" />
   </ItemGroup>
   <ItemGroup>
-    <Image Include="bedrock.png" />
-    <Image Include="logo.png" />
-    <Image Include="proj.png" />
     <Image Include="resources\bedrock.png" />
     <Image Include="resources\proj.png" />
   </ItemGroup>

--- a/BattleFriends/BattleFriends.vcxproj.filters
+++ b/BattleFriends/BattleFriends.vcxproj.filters
@@ -87,15 +87,6 @@
     <Image Include="resources\bedrock.png">
       <Filter>Resource Files</Filter>
     </Image>
-    <Image Include="logo.png">
-      <Filter>Resource Files</Filter>
-    </Image>
-    <Image Include="proj.png">
-      <Filter>Resource Files</Filter>
-    </Image>
-    <Image Include="bedrock.png">
-      <Filter>Resource Files</Filter>
-    </Image>
   </ItemGroup>
   <ItemGroup>
     <Font Include="resources\fonts\raleway\Raleway-Bold.ttf">

--- a/BattleFriends/src/BF.cpp
+++ b/BattleFriends/src/BF.cpp
@@ -10,7 +10,7 @@ sf::VideoMode BF::screen_params;
 sf::View player_view;
 sf::View default_view;
 sf::Sprite background;
-std::map<int, sf::Texture> textures;
+std::unordered_map<int, sf::Texture> BF::textures;
 
 #ifdef _DEBUG
 sf::Texture& get_background_texture()    //I have to use this because sf::Texture doesn't support global initialization in debug mode
@@ -20,7 +20,7 @@ sf::Texture& get_background_texture()    //I have to use this because sf::Textur
 }
 #define background_texture get_background_texture()
 #else
-static sf::Texture background_texture;
+sf::Texture background_texture;
 #endif // _DEBUG
 
 void BF::updateEntities()
@@ -41,7 +41,15 @@ void BF::updatePlayers()
 
 void BF::loadTextures()
 {
-	textures.emplace(,);
+	sf::Texture tex;
+	EnumResourceNamesA(NULL, "PNG",
+		[](HMODULE hModule, LPCTSTR lpType, LPTSTR lpName, LONG_PTR lParam) -> BOOL
+		{
+			BF::loadResource((int)lpName, lpType, *((sf::Texture*)lParam));
+			textures.emplace((int)lpName, *((sf::Texture*)lParam));
+			return true; // Continue enumeration
+		},
+		(LONG_PTR)&tex);
 }
 
 void BF::updateProjectiles()
@@ -57,6 +65,8 @@ void BF::init(sf::RenderTarget* target)
 	entities.reserve(100);
 	players.reserve(32);
 	projectiles.reserve(1000);
+
+	loadTextures();
 
 	background_texture.loadFromFile("resources/bedrock.png");
 	background_texture.setRepeated(true);
@@ -80,6 +90,7 @@ void BF::clear()
 	entities.clear();
 	players.clear();
 	projectiles.clear();
+	textures.clear();
 }
 
 void BF::update()
@@ -186,11 +197,11 @@ void BF::checkHits()
 void BF::spawn_random_ent()
 {
 	srand(time(NULL));
-	players.emplace_back("resources/logo.png");
+	players.emplace_back(logo);
 	players[0].move(MAP_WIDTH / 2, MAP_HEIGHT / 2);
 	for (int i = 0; i < ENTITY_NUM; i++)
 	{
-		entities.emplace_back("resources/logo.png");
+		entities.emplace_back(logo);
 		entities[i].setColor(sf::Color{255, 100, 100});
 		entities[i].move(rand() % MAP_WIDTH, rand() % MAP_HEIGHT);
 		if (!(rand() % 10))

--- a/BattleFriends/src/Entity.cpp
+++ b/BattleFriends/src/Entity.cpp
@@ -1,9 +1,9 @@
 #include <pch.h>
 #include <Entity.h>
+#include <BF.h>
 
 
-
-
+/*
 BF::Entity::Entity(const char* filename)
 {
 	m_Texture.loadFromFile(filename);
@@ -16,11 +16,19 @@ BF::Entity::Entity(const char* filename)
 
 	std::cout << "Created Entity" << std::endl;
 }
-
+*/
 
 BF::Entity::Entity(int textureID)
+	:m_textureID(textureID)
 {
+	setTexture(textures[textureID]);
 
+	sf::FloatRect bounding_box = getLocalBounds();
+	setOrigin(bounding_box.width / 2.f, bounding_box.height / 2.f);
+	radius = bounding_box.width < bounding_box.height ?
+		bounding_box.width / 2.f : bounding_box.height / 2.f;
+
+	std::cout << "Created Entity" << std::endl;
 }
 
 BF::Entity::~Entity()
@@ -33,8 +41,8 @@ BF::Entity::Entity(Entity&& other) noexcept
 	:sf::Sprite(std::move(other))
 {
 	std::cout << "Entity moved\n";
-	m_Texture = other.m_Texture;
-	setTexture(m_Texture);
+	m_textureID = other.m_textureID;
+	setTexture(textures[m_textureID]);
 	radius = other.radius;
 	setPosition(other.getPosition());
 	setSpeed(other.m_SpeedX, other.m_SpeedY);
@@ -48,8 +56,8 @@ BF::Entity& BF::Entity::operator=(const Entity& other)
 	if (this != &other)
 	{
 		radius = other.radius;
-		m_Texture = other.m_Texture;
-		setTexture(m_Texture);
+		m_textureID = other.m_textureID;
+		setTexture(textures[m_textureID]);
 		setPosition(other.getPosition());
 		setSpeed(other.m_SpeedX, other.m_SpeedY);
 		health = other.health;
@@ -64,8 +72,8 @@ BF::Entity& BF::Entity::operator=(const Entity&& other) noexcept
 	if (this != &other)
 	{
 		radius = other.radius;
-		m_Texture = other.m_Texture;
-		setTexture(m_Texture);
+		m_textureID = other.m_textureID;
+		setTexture(textures[m_textureID]);
 		setPosition(other.getPosition());
 		setSpeed(other.m_SpeedX, other.m_SpeedY);
 		health = other.health;

--- a/BattleFriends/src/Player.cpp
+++ b/BattleFriends/src/Player.cpp
@@ -3,8 +3,16 @@
 #include <BF.h>
 
 
+/*
 BF::Player::Player(const char* filename)
 	:Entity(filename)
+{
+	std::cout << "Created Player" << std::endl;
+}
+*/
+
+BF::Player::Player(int textureID)
+	:Entity(textureID)
 {
 	std::cout << "Created Player" << std::endl;
 }

--- a/BattleFriends/src/Projectile.cpp
+++ b/BattleFriends/src/Projectile.cpp
@@ -5,7 +5,7 @@
 
 
 BF::Projectile::Projectile(const sf::Vector2f& pos, const sf::Vector2f& speed)
-	:Entity("resources/proj.png")
+	:Entity(proj)
 {
 	health = 1;
 	setPosition(pos.x, pos.y);

--- a/BattleFriends/src/include/BF.h
+++ b/BattleFriends/src/include/BF.h
@@ -15,6 +15,7 @@ namespace BF
 	extern std::vector<Projectile> projectiles;
 	extern sf::RenderTarget* default_target;
 	extern sf::VideoMode screen_params;
+	extern std::unordered_map<int, sf::Texture> textures;
 
 	void loadTextures();
 

--- a/BattleFriends/src/include/BFconstants.h
+++ b/BattleFriends/src/include/BFconstants.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define ENTITY_NUM 100
+#define ENTITY_NUM 1000
 const int MAP_WIDTH = 8192;
 const int MAP_HEIGHT = 8192;
 const float MINIMAP_SCALE = 0.05f;  // in fraction of map size

--- a/BattleFriends/src/include/Entity.h
+++ b/BattleFriends/src/include/Entity.h
@@ -6,7 +6,7 @@ namespace BF
 	class Entity : public sf::Sprite
 	{
 	public:
-		Entity(const char* filename);
+		//Entity(const char* filename);
 		Entity(int textureID);
 		Entity() = delete;
 		Entity(Entity&) = delete;
@@ -27,7 +27,8 @@ namespace BF
 
 	protected:
 		float radius = 1.f;
-		sf::Texture m_Texture;
+		//sf::Texture m_Texture;
+		int m_textureID = 0;
 		float m_SpeedX = 0.f, m_SpeedY = 0.f;
 		int health = 100;
 

--- a/BattleFriends/src/include/Player.h
+++ b/BattleFriends/src/include/Player.h
@@ -6,7 +6,8 @@ namespace BF
 	class Player : public Entity
 	{
 	public:
-		Player(const char* filename);
+		//Player(const char* filename);
+		Player(int textureID);
 		Player() = delete;
 		Player(Player&& other) noexcept;
 		Player& operator= (const Player&) = default;

--- a/BattleFriends/src/include/loadResource.h
+++ b/BattleFriends/src/include/loadResource.h
@@ -5,7 +5,7 @@ namespace BF
 	template<typename SFML_type>
 	bool loadResource(int name, const char* type, SFML_type &obj)
 	{
-		HRSRC hResource = FindResourceA(NULL, MAKEINTRESOURCE(name), TEXT(type));
+		HRSRC hResource = FindResourceA(NULL, (LPCSTR)name, type);
 		if (hResource != NULL)
 		{
 			DWORD resourceSize = SizeofResource(NULL, hResource);

--- a/BattleFriends/src/include/pch.h
+++ b/BattleFriends/src/include/pch.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <iostream>
+#include <unordered_map>
 
 #define NOMINMAX    // #define min() from minwindef.h breaks std::min used in SFML
 #include <Windows.h>

--- a/BattleFriends/src/main.cpp
+++ b/BattleFriends/src/main.cpp
@@ -6,7 +6,7 @@
 int main()
 {
 	sf::RenderWindow window(sf::VideoMode::getDesktopMode(), "BattleFriends", sf::Style::Fullscreen);
-	window.setFramerateLimit(240);
+	//window.setFramerateLimit(240);
 
 	BF::init(&window);
 	BF::spawn_random_ent();
@@ -32,6 +32,7 @@ int main()
 	Esc_hint.setString("Press Esc to exit");
 	#endif // SHOW_FPS
 
+
 	while (window.isOpen())
 	{
 		sf::Event event;
@@ -55,6 +56,7 @@ int main()
 		window.draw(Entities_count);
 		window.draw(Projectiles_count);
 		window.draw(Esc_hint);
+
 		frames++;
 		if (frames == 10)
 		{


### PR DESCRIPTION
It turns out that using a separate copy of a texture for each entity doesn't really affect performance (for ~1000 textures used). Performance probably capped by CPU because collision logic is single-threaded.